### PR TITLE
[bugfix] [langchain]Fix Followup Question categorization not recognizing system prompt

### DIFF
--- a/package/api/lang_folder/agents.py
+++ b/package/api/lang_folder/agents.py
@@ -24,7 +24,7 @@ def get_ai_response_for_conversation(conversation):
     return result
 
 def get_follow_up_questions_from_ai(conversation):
-    formatted_conversation = [('ai' if entry["role"] == 'assistant' else 'human', entry["content"]) for entry in conversation]
+    formatted_conversation = [('ai' if entry["role"] == 'assistant' or entry["role"] == 'system' else 'human', entry["content"]) for entry in conversation]
     result = follow_up_questions_chain.invoke({"table_info" : db.table_info , "conversation" : formatted_conversation})
     return result
 


### PR DESCRIPTION
### Description

In the current implementation, initial system prompts with instructions for follow up questions get incorrectly categorized as 'human' rather than 'ai' due to the logic not taking into account that the initial followup question prompt uses a role of 'system'.


### Testing
This was deployed locally and tested in langsmith to ensure that the fix took effect, see the correct categorization here:
![image](https://github.com/parthasarathydNU/protien-data-visualizer/assets/94765236/d49f4121-9b6b-4d9a-8823-0124f5569599)
