### PR TITLE
[bugfix] convert repository owner name to lowercase

### DIFF
--- a/.github/workflows/build-push-genoquery-api.yml
+++ b/.github/workflows/build-push-genoquery-api.yml
@@ -23,6 +23,10 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
+    - name: Convert repository owner to lowercase
+      id: convert-owner
+      run: echo "REPO_OWNER=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+
     - name: Build and push Docker image
       uses: docker/build-push-action@v4
       with:
@@ -30,5 +34,6 @@ jobs:
         file: ./package/api/dockerfile
         push: true
         tags: |
-          ghcr.io/${{ github.repository_owner }}/genoquery-api:latest
-          ghcr.io/${{ github.repository_owner }}/genoquery-api:${{ github.sha }}
+          ghcr.io/${{ env.REPO_OWNER }}/genoquery-api:latest
+          ghcr.io/${{ env.REPO_OWNER }}/genoquery-api:${{ github.sha }}
+


### PR DESCRIPTION
### Description
Currently, our workflow fails, as parthasarathydNU contains uppercase letters and ghcr.io doesn't allow uppercase letters. This fix converts the repository owner name to lowercase to avoid this error.


### Testing

Regression tested on my fork, you can see the result [here](https://github.com/krisciu/protien-data-visualizer/actions/runs/9712592988/job/26807957795)