### PR TITLE
Enabled storage of generated charts in the DB

### DIFF
--- a/package/api/lang_folder/templates.py
+++ b/package/api/lang_folder/templates.py
@@ -118,6 +118,9 @@ You carefully analyzes the conversation context and dataset metadata, then craft
 
 
 Given the above table metadata and the conversation context below, generate a Vega-Lite chart specification that matches the user query
+
+Ensure to include the chart title in the generated spec
+Ensure to make the charts interactive
 """
 
 SYSTEM_PROMPT_FOR_CHART_CONVERSATION_TEMPLATE = """
@@ -155,7 +158,7 @@ User: Could you explain what a stacked bar chart looks like?
 VegaVizExpert: Certainly! A stacked bar chart places segments of data on top of each other within each category on the x-axis. For example, if each bar represents a month, the segments in each bar would represent the sales of each product for that month, stacked on top of each other. This type of chart is useful for understanding the proportion of each product's sales to the total monthly sales. Would you like to go with this type of chart, or explore more options?
 
 # Model's Task:
-Engage in the conversation based on the user's responses, guide them through choosing the best chart for their data, and ensure they understand how to read and interpret the visual information effectively.
+Engage in the conversation based on the user's responses, guide them through choosing the best chart for their data, and ensure they understand how to read and interpret the visual information effectively. Ensure to provide responses in markdown format only.
 
 Here is information about the data source : 
 

--- a/package/api/models.py
+++ b/package/api/models.py
@@ -1,5 +1,6 @@
-from sqlalchemy import Table, Column, Integer, String, Float, Date, JSON, Text
+from sqlalchemy import Table, Column, Integer, String, Float, Date, JSON, Text, text
 from sqlalchemy.sql.sqltypes import Float
+from sqlalchemy.dialects.postgresql import UUID
 from database import metadata
 
 protein_data = Table(
@@ -70,4 +71,11 @@ gff_annotations = Table(
     Column("strand", String(1)),
     Column("phase", String(1)),
     Column("attributes", Text),
+)
+
+charts = Table(
+    "charts", metadata,
+    Column("chart_id", UUID(as_uuid=True), primary_key=True, server_default=text("uuid_generate_v4()")),
+    Column("chart_data", JSON),
+    Column("chart_spec", JSON),
 )

--- a/package/api/queryModel.py
+++ b/package/api/queryModel.py
@@ -21,6 +21,9 @@ class ChartQueryResponse(BaseModel):
     type: ChatResponseTypes
     response: str
 
+class CreateChartRequest(BaseModel):
+    chart_data: str
+    chart_spec: str
 
 # QUERY PROMPTS =====================================
 DB_SCHEMA = """

--- a/package/dashboards/protein-dashboard/package-lock.json
+++ b/package/dashboards/protein-dashboard/package-lock.json
@@ -12,6 +12,7 @@
         "@radix-ui/react-label": "^2.1.0",
         "@radix-ui/react-slot": "^1.1.0",
         "@radix-ui/react-tabs": "^1.1.0",
+        "@radix-ui/react-tooltip": "^1.1.2",
         "@tanstack/react-query": "^5.49.2",
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^13.4.0",
@@ -2631,6 +2632,40 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@floating-ui/core": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.4.tgz",
+      "integrity": "sha512-a4IowK4QkXl4SCWTGUR0INAfEOX3wtsYw3rKK5InQEHMGObkR8Xk44qYQD9P4r6HHw0iIfK6GUKECmY8sTkqRA==",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.4"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.7.tgz",
+      "integrity": "sha512-wmVfPG5o2xnKDU4jx/m4w5qva9FWHcnZ8BvzEe90D/RpwsJaTAVYPEPdQ8sbr/N8zZTAHlZUTQdqg8ZUbzHmng==",
+      "dependencies": {
+        "@floating-ui/core": "^1.6.0",
+        "@floating-ui/utils": "^0.2.4"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.1.tgz",
+      "integrity": "sha512-4h84MJt3CHrtG18mGsXuLCHMrug49d7DFkU0RMIyshRveBeyV2hmV/pDaF2Uxtu8kgq5r46llp5E5FQiR0K2Yg==",
+      "dependencies": {
+        "@floating-ui/dom": "^1.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.4.tgz",
+      "integrity": "sha512-dWO2pw8hhi+WrXq1YJy2yCuWoL20PddgGaqTgVe4cOS9Q6qklXCiA1tJEqX6BEwRNSCP84/afac9hd4MS+zEUA=="
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.14",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
@@ -3228,6 +3263,28 @@
       "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.0.tgz",
       "integrity": "sha512-4Z8dn6Upk0qk4P74xBhZ6Hd/w0mPEzOOLxy4xiPXOXqjF7jZS0VAKk7/x/H6FyY2zCkYJqePf1G5KmkmNJ4RBA=="
     },
+    "node_modules/@radix-ui/react-arrow": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.0.tgz",
+      "integrity": "sha512-FmlW1rCg7hBpEBwFbjHwCW6AmWLQM6g/v0Sn8XbP9NvmSZ2San1FpQeyPtufzOMSIx7Y4dzjlHoifhp+7NkZhw==",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.0.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-collection": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.0.tgz",
@@ -3433,6 +3490,37 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-popper": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.0.tgz",
+      "integrity": "sha512-ZnRMshKF43aBxVWPWvbj21+7TQCvhuULWJ4gNIKYpRlQt5xGRhLx66tMp8pya2UkGHTSlhpXwmjqltDYHhw7Vg==",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.0.0",
+        "@radix-ui/react-arrow": "1.1.0",
+        "@radix-ui/react-compose-refs": "1.1.0",
+        "@radix-ui/react-context": "1.1.0",
+        "@radix-ui/react-primitive": "2.0.0",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.0",
+        "@radix-ui/react-use-rect": "1.1.0",
+        "@radix-ui/react-use-size": "1.1.0",
+        "@radix-ui/rect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-portal": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.1.tgz",
@@ -3577,6 +3665,39 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-tooltip": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.1.2.tgz",
+      "integrity": "sha512-9XRsLwe6Yb9B/tlnYCPVUd/TFS4J7HuOZW345DCeC6vKIxQGMZdx21RK4VoZauPD5frgkXTYVS5y90L+3YBn4w==",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.0",
+        "@radix-ui/react-compose-refs": "1.1.0",
+        "@radix-ui/react-context": "1.1.0",
+        "@radix-ui/react-dismissable-layer": "1.1.0",
+        "@radix-ui/react-id": "1.1.0",
+        "@radix-ui/react-popper": "1.2.0",
+        "@radix-ui/react-portal": "1.1.1",
+        "@radix-ui/react-presence": "1.1.0",
+        "@radix-ui/react-primitive": "2.0.0",
+        "@radix-ui/react-slot": "1.1.0",
+        "@radix-ui/react-use-controllable-state": "1.1.0",
+        "@radix-ui/react-visually-hidden": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-use-callback-ref": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.0.tgz",
@@ -3638,6 +3759,67 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@radix-ui/react-use-rect": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.0.tgz",
+      "integrity": "sha512-0Fmkebhr6PiseyZlYAOtLS+nb7jLmpqTrJyv61Pe68MKYW6OWdRE2kI70TaYY27u7H0lajqM3hSMMLFq18Z7nQ==",
+      "dependencies": {
+        "@radix-ui/rect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-size": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.0.tgz",
+      "integrity": "sha512-XW3/vWuIXHa+2Uwcc2ABSfcCledmXhhQPlGbfcRXbiUQI5Icjcg19BGCZVKKInYbvUCut/ufbbLLPFC5cbb1hw==",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-visually-hidden": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.1.0.tgz",
+      "integrity": "sha512-N8MDZqtgCgG5S3aV60INAB475osJousYpZ4cTJ2cFbMpdHS5Y6loLTH8LPtkj2QN0x93J30HT/M3qJXM0+lyeQ==",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.0.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/rect": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.0.tgz",
+      "integrity": "sha512-A9+lCBZoaMJlVKcRBz2YByCG+Cp2t6nAnMnNba+XiWxnj6r4JUFqfsgwocMBZU9LPtdxC6wB56ySYpc7LQIoJg=="
     },
     "node_modules/@remix-run/router": {
       "version": "1.16.1",

--- a/package/dashboards/protein-dashboard/package-lock.json
+++ b/package/dashboards/protein-dashboard/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.1",
+        "@radix-ui/react-label": "^2.1.0",
         "@radix-ui/react-slot": "^1.1.0",
         "@radix-ui/react-tabs": "^1.1.0",
         "@tanstack/react-query": "^5.49.2",
@@ -29,6 +30,7 @@
         "react-chartjs-2": "^5.2.0",
         "react-dom": "^18.3.1",
         "react-gauge-chart": "^0.5.1",
+        "react-icons": "^4.2.0",
         "react-markdown": "^9.0.1",
         "react-resizable": "^3.0.5",
         "react-router-dom": "^6.23.1",
@@ -3405,6 +3407,28 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-label": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.0.tgz",
+      "integrity": "sha512-peLblDlFw/ngk3UWq0VnYaOLy6agTZZ+MUO/WhVfm14vJGML+xH4FAl2XQGLqdefjNb7ApRg6Yn7U42ZhmYXdw==",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.0.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }
@@ -15963,6 +15987,14 @@
       "peerDependencies": {
         "react": "^16.8.2 || ^17.0 || ^18.x",
         "react-dom": "^16.8.2 || ^17.0 || ^18.x"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.2.0.tgz",
+      "integrity": "sha512-rmzEDFt+AVXRzD7zDE21gcxyBizD/3NqjbX6cmViAgdqfJ2UiLer8927/QhhrXQV7dEj/1EGuOTPp7JnLYVJKQ==",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-intersection-observer": {

--- a/package/dashboards/protein-dashboard/package.json
+++ b/package/dashboards/protein-dashboard/package.json
@@ -7,6 +7,7 @@
     "@radix-ui/react-label": "^2.1.0",
     "@radix-ui/react-slot": "^1.1.0",
     "@radix-ui/react-tabs": "^1.1.0",
+    "@radix-ui/react-tooltip": "^1.1.2",
     "@tanstack/react-query": "^5.49.2",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",

--- a/package/dashboards/protein-dashboard/package.json
+++ b/package/dashboards/protein-dashboard/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.1",
+    "@radix-ui/react-label": "^2.1.0",
     "@radix-ui/react-slot": "^1.1.0",
     "@radix-ui/react-tabs": "^1.1.0",
     "@tanstack/react-query": "^5.49.2",
@@ -24,6 +25,7 @@
     "react-chartjs-2": "^5.2.0",
     "react-dom": "^18.3.1",
     "react-gauge-chart": "^0.5.1",
+    "react-icons": "^4.2.0",
     "react-markdown": "^9.0.1",
     "react-resizable": "^3.0.5",
     "react-router-dom": "^6.23.1",

--- a/package/dashboards/protein-dashboard/src/@/components/ui/input.tsx
+++ b/package/dashboards/protein-dashboard/src/@/components/ui/input.tsx
@@ -1,0 +1,25 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+export interface InputProps
+  extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        className={cn(
+          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Input.displayName = "Input"
+
+export { Input }

--- a/package/dashboards/protein-dashboard/src/@/components/ui/label.tsx
+++ b/package/dashboards/protein-dashboard/src/@/components/ui/label.tsx
@@ -1,0 +1,24 @@
+import * as React from "react"
+import * as LabelPrimitive from "@radix-ui/react-label"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const labelVariants = cva(
+  "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+)
+
+const Label = React.forwardRef<
+  React.ElementRef<typeof LabelPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> &
+    VariantProps<typeof labelVariants>
+>(({ className, ...props }, ref) => (
+  <LabelPrimitive.Root
+    ref={ref}
+    className={cn(labelVariants(), className)}
+    {...props}
+  />
+))
+Label.displayName = LabelPrimitive.Root.displayName
+
+export { Label }

--- a/package/dashboards/protein-dashboard/src/@/components/ui/tooltip.tsx
+++ b/package/dashboards/protein-dashboard/src/@/components/ui/tooltip.tsx
@@ -1,0 +1,28 @@
+import * as React from "react"
+import * as TooltipPrimitive from "@radix-ui/react-tooltip"
+
+import { cn } from "@/lib/utils"
+
+const TooltipProvider = TooltipPrimitive.Provider
+
+const Tooltip = TooltipPrimitive.Root
+
+const TooltipTrigger = TooltipPrimitive.Trigger
+
+const TooltipContent = React.forwardRef<
+  React.ElementRef<typeof TooltipPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
+>(({ className, sideOffset = 4, ...props }, ref) => (
+  <TooltipPrimitive.Content
+    ref={ref}
+    sideOffset={sideOffset}
+    className={cn(
+      "z-50 overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      className
+    )}
+    {...props}
+  />
+))
+TooltipContent.displayName = TooltipPrimitive.Content.displayName
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider }

--- a/package/dashboards/protein-dashboard/src/api/api.ts
+++ b/package/dashboards/protein-dashboard/src/api/api.ts
@@ -1,3 +1,4 @@
+import { ChartsData } from "components/dynamicCharts/types";
 import { apiRequest } from "../utils/apiUtils";
 import { ProteinData } from "./apiDataTypes";
 import { GetUseQuery } from "./hooks";
@@ -47,6 +48,18 @@ export const fetchProteinCalculations = async (entry: string) => {
 export const fetchProtein = async (entry: string): Promise<ProteinData> => {
   return apiRequest<any>({ method: "get", url: `proteins/${entry}` });
 };
+
+export const saveChart = async ({ chart_data, chart_spec }: ChartsData) => {
+  const payload = {
+    chart_data: JSON.stringify(chart_data),
+    chart_spec: JSON.stringify(chart_spec),
+  };
+  return apiRequest<any>({ method: "post", url: `create_chart`, payload });
+};
+
+export const fetchCharts =  () => {
+  return apiRequest<any[]>({ method: "get", url: `get_sample/${"charts"}` })
+}
 
 export const createProtein = async (protein: any) => {
   return apiRequest<any>({

--- a/package/dashboards/protein-dashboard/src/components/dynamicCharts/ChartControlSheet.tsx
+++ b/package/dashboards/protein-dashboard/src/components/dynamicCharts/ChartControlSheet.tsx
@@ -1,36 +1,40 @@
 import React from "react";
 import {
-    Sheet,
-    SheetContent,
-    SheetDescription,
-    SheetHeader,
-    SheetTitle,
-    SheetTrigger,
-  } from "@/components/ui/sheet";
-  import { IoIosSettings } from "react-icons/io";
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTrigger,
+} from "@/components/ui/sheet";
+
+
+import { IoIosSettings } from "react-icons/io";
 import { Button } from "@/components/ui/button";
 import ChartControls from "./ChartControls";
 
 interface ChartControlSheetProps {
-    selectedChartIndex: number
-    chart_spec: JSON
-    updateChartSpec: (spec:JSON) => void
+  chart_spec: JSON;
+  updateChartSpec: (spec: JSON) => void;
 }
 
-const ChartControlSheet: React.FC<ChartControlSheetProps> = ({selectedChartIndex, chart_spec, updateChartSpec}) => {
+const ChartControlSheet: React.FC<ChartControlSheetProps> = ({
+  chart_spec,
+  updateChartSpec,
+}) => {
   return (
     <Sheet>
       <SheetTrigger>
         {" "}
-        <Button variant={"link"} size="icon" className="absolute top-0 right-0">
+        <Button
+          variant={"link"}
+          size="icon"
+          className="absolute bottom-0 left-0"
+        >
           <IoIosSettings />
         </Button>
       </SheetTrigger>
       <SheetContent>
         <SheetHeader>
-          <SheetTitle>
-            Change Chart Setting - Chart {selectedChartIndex + 1}
-          </SheetTitle>
           <SheetDescription>
             <ChartControls
               onSpecChange={(newSpec: any) => {

--- a/package/dashboards/protein-dashboard/src/components/dynamicCharts/ChartControlSheet.tsx
+++ b/package/dashboards/protein-dashboard/src/components/dynamicCharts/ChartControlSheet.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import {
+    Sheet,
+    SheetContent,
+    SheetDescription,
+    SheetHeader,
+    SheetTitle,
+    SheetTrigger,
+  } from "@/components/ui/sheet";
+  import { IoIosSettings } from "react-icons/io";
+import { Button } from "@/components/ui/button";
+import ChartControls from "./ChartControls";
+
+interface ChartControlSheetProps {
+    selectedChartIndex: number
+    chart_spec: JSON
+    updateChartSpec: (spec:JSON) => void
+}
+
+const ChartControlSheet: React.FC<ChartControlSheetProps> = ({selectedChartIndex, chart_spec, updateChartSpec}) => {
+  return (
+    <Sheet>
+      <SheetTrigger>
+        {" "}
+        <Button variant={"link"} size="icon" className="absolute top-0 right-0">
+          <IoIosSettings />
+        </Button>
+      </SheetTrigger>
+      <SheetContent>
+        <SheetHeader>
+          <SheetTitle>
+            Change Chart Setting - Chart {selectedChartIndex + 1}
+          </SheetTitle>
+          <SheetDescription>
+            <ChartControls
+              onSpecChange={(newSpec: any) => {
+                updateChartSpec(newSpec);
+              }}
+              spec={chart_spec}
+            />
+          </SheetDescription>
+        </SheetHeader>
+      </SheetContent>
+    </Sheet>
+  );
+};
+
+export default ChartControlSheet;

--- a/package/dashboards/protein-dashboard/src/components/dynamicCharts/ChartControls.jsx
+++ b/package/dashboards/protein-dashboard/src/components/dynamicCharts/ChartControls.jsx
@@ -1,10 +1,10 @@
-import React from 'react';
-import "./styles/ChartControls.css"
+import React from "react";
+import "./styles/ChartControls.css";
 
 class ChartControls extends React.Component {
   handleInputChange = (propertyPath, value) => {
     const newSpec = { ...this.props.spec };
-    const pathSegments = propertyPath.split('.');
+    const pathSegments = propertyPath.split(".");
     let current = newSpec;
 
     pathSegments.forEach((segment, index) => {
@@ -28,7 +28,7 @@ class ChartControls extends React.Component {
         <input
           className="control-input"
           type="text"
-          value={value || ''}
+          value={value || ""}
           onChange={(e) => this.handleInputChange(propertyPath, e.target.value)}
         />
       </div>
@@ -41,7 +41,7 @@ class ChartControls extends React.Component {
 
     // Chart title
     if (spec.title) {
-      controls.push(this.renderControl('Title', 'title', spec.title));
+      controls.push(this.renderControl("Title", "title", spec.title));
     }
 
     // Mark type
@@ -52,7 +52,7 @@ class ChartControls extends React.Component {
           <select
             className="control-select"
             value={spec.mark}
-            onChange={(e) => this.handleInputChange('mark', e.target.value)}
+            onChange={(e) => this.handleInputChange("mark", e.target.value)}
           >
             <option value="bar">Bar</option>
             <option value="line">Line</option>
@@ -60,7 +60,15 @@ class ChartControls extends React.Component {
             <option value="area">Area</option>
             <option value="rect">Rect</option>
             <option value="boxplot">Boxplot</option>
-            {/* Add other mark types as needed */}
+            <option value="arc">Arc</option>
+            <option value="image">Image</option>
+            <option value="group">Group</option>
+            <option value="path">Path</option>
+            <option value="rule">Rule</option>
+            <option value="shape">Shape</option>
+            <option value="symbol">Symbol</option>
+            <option value="text">Text</option>
+            <option value="trail">Trail</option>
           </select>
         </div>
       );
@@ -91,11 +99,18 @@ class ChartControls extends React.Component {
         if (channelSpec.type) {
           controls.push(
             <div key={`encoding.${channel}.type`} className="control-group">
-              <label className="control-label">{`${channel.toUpperCase()} Type`}:</label>
+              <label className="control-label">
+                {`${channel.toUpperCase()} Type`}:
+              </label>
               <select
                 className="control-select"
                 value={channelSpec.type}
-                onChange={(e) => this.handleInputChange(`encoding.${channel}.type`, e.target.value)}
+                onChange={(e) =>
+                  this.handleInputChange(
+                    `encoding.${channel}.type`,
+                    e.target.value
+                  )
+                }
               >
                 <option value="nominal">Nominal</option>
                 <option value="ordinal">Ordinal</option>
@@ -117,8 +132,16 @@ class ChartControls extends React.Component {
           <input
             className="control-color"
             type="color"
-            value={spec.encoding.color.scale.range ? spec.encoding.color.scale.range[0] : '#000000'}
-            onChange={(e) => this.handleInputChange('encoding.color.scale.range', [e.target.value])}
+            value={
+              spec.encoding.color.scale.range
+                ? spec.encoding.color.scale.range[0]
+                : "#000000"
+            }
+            onChange={(e) =>
+              this.handleInputChange("encoding.color.scale.range", [
+                e.target.value,
+              ])
+            }
           />
         </div>
       );

--- a/package/dashboards/protein-dashboard/src/components/dynamicCharts/Visualize.tsx
+++ b/package/dashboards/protein-dashboard/src/components/dynamicCharts/Visualize.tsx
@@ -94,11 +94,13 @@ function Visualize() {
                       onClick={() => setSelectedChartIndex(index)}
                     >
                       <VegaChart data={chart_data} spec={chart_spec} />
+                      <div title="Settings">
+
                       <ChartControlSheet 
-                      selectedChartIndex={selectedChartIndex} 
                       chart_spec={chart_spec}
                       updateChartSpec={updateChartSpec}
                        />
+                      </div>
                     </div>
                   </DynamicResizableBox>
                 ))}

--- a/package/dashboards/protein-dashboard/src/components/dynamicCharts/Visualize.tsx
+++ b/package/dashboards/protein-dashboard/src/components/dynamicCharts/Visualize.tsx
@@ -3,14 +3,33 @@ import DynamicResizableBox from "./DynamicResizableBox";
 import "./styles/Visualize.css";
 import { Fade } from "react-awesome-reveal";
 import ChartControls from "./ChartControls";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import AddNewChart from "./AddNewChart";
 import { ChartsData } from "./types";
+import { fetchCharts, fetchSamples, saveChart } from "api/api";
 
 function Visualize() {
+  const [selectedChartIndex, setSelectedChartIndex] = useState<number>(-1);
+
   const [chartsData, setChartsData] = useState<ChartsData[]>([]);
 
-  const [selectedChartIndex, setSelectedChartIndex] = useState<number>(-1);
+  useEffect(() => {
+    const fetchChartsData = async () => {
+      const dbChartsData = await fetchCharts();
+      const parsedChartsData = dbChartsData?.map((chartData) => {
+        return {
+          chart_data: JSON.parse(chartData.chart_data),
+          chart_spec: JSON.parse(chartData.chart_spec),
+        } as ChartsData;
+      });
+
+      if (parsedChartsData) {
+        const updatedChartsData = [...chartsData, ...parsedChartsData];
+        setChartsData(updatedChartsData);
+      }
+    };
+    fetchChartsData();
+  }, []);
 
   const updateChartSpec = (newSpec: any) => {
     if (selectedChartIndex < 0 || selectedChartIndex >= chartsData.length) {
@@ -29,10 +48,12 @@ function Visualize() {
     setChartsData(newChartsData);
   };
 
-  const saveChart = (chartInfo: ChartsData): void => {
+  const saveChartFn = (chartInfo: ChartsData) => {
     // Append this to the list of charts we have in this view
     const updatedCharts = [...chartsData, chartInfo];
     setChartsData(updatedCharts);
+    console.log("saving chart");
+    saveChart(chartInfo);
   };
 
   return (
@@ -48,58 +69,58 @@ function Visualize() {
             {/* <button className="new-chart bg-blue-600">
               New Chart
             </button> */}
-            {chartsData.length > 0 && <AddNewChart saveChart={saveChart} />}
+            {chartsData.length > 0 && <AddNewChart saveChart={saveChartFn} />}
           </div>
         </header>
       </Fade>
-      <div style={{ height: "90%", overflowY: "scroll" }} className={`${chartsData.length == 0 ? "grid" : "block"}`}>
+      <div
+        style={{ height: "90%", overflowY: "scroll" }}
+        className={`${chartsData.length == 0 ? "grid" : "block"}`}
+      >
         {chartsData.length > 0 ? (
-                  <Fade delay={500} duration={300} className="h-full">
-                  <section className="grid-wrapper">
-                    <div className="charts-panel">
-                      {chartsData.map(({ chartData, chartSpec }, index) => (
-                        <DynamicResizableBox
-                          key={index}
-                          width={300}
-                          minConstraints={[200, 150]}
-                          maxConstraints={[800, 600]}
-                        >
-                          <div
-                            className="chartDiv"
-                            onClick={() => setSelectedChartIndex(index)}
-                          >
-                            <VegaChart data={chartData} spec={chartSpec} />
-                          </div>
-                        </DynamicResizableBox>
-                      ))}
-                      {chartsData.length == 0 && (
-                        <div className="flex justify-center align-middle">
-                          <AddNewChart saveChart={saveChart} />
-                        </div>
-                      )}
+          <Fade delay={500} duration={300} className="h-full">
+            <section className="grid-wrapper">
+              <div className="charts-panel">
+                {chartsData.map(({ chart_data, chart_spec }, index) => (
+                  <DynamicResizableBox
+                    key={index}
+                    width={300}
+                    minConstraints={[200, 150]}
+                    maxConstraints={[800, 600]}
+                  >
+                    <div
+                      className="chartDiv"
+                      onClick={() => setSelectedChartIndex(index)}
+                    >
+                      <VegaChart data={chart_data} spec={chart_spec} />
                     </div>
-                    {chartsData.length > 0 && (
-                      <div className="chartControls">
-                        {chartsData[selectedChartIndex] ? (
-                          <ChartControls
-                            onSpecChange={(newSpec: any) => {
-                              updateChartSpec(newSpec);
-                            }}
-                            spec={chartsData[selectedChartIndex].chartSpec}
-                          />
-                        ) : (
-                          "Select a chart to see controls"
-                        )}
-                      </div>
-                    )}
-                  </section>
-                </Fade>
+                  </DynamicResizableBox>
+                ))}
+                {chartsData.length == 0 && (
+                  <div className="flex justify-center align-middle">
+                    <AddNewChart saveChart={saveChartFn} />
+                  </div>
+                )}
+              </div>
+              {chartsData.length > 0 && (
+                <div className="chartControls">
+                  {chartsData[selectedChartIndex] ? (
+                    <ChartControls
+                      onSpecChange={(newSpec: any) => {
+                        updateChartSpec(newSpec);
+                      }}
+                      spec={chartsData[selectedChartIndex].chart_spec}
+                    />
+                  ) : (
+                    "Select a chart to see controls"
+                  )}
+                </div>
+              )}
+            </section>
+          </Fade>
         ) : (
-          <AddNewChart saveChart={saveChart} />
-        )
-        
-      }
-
+          <AddNewChart saveChart={saveChartFn} />
+        )}
       </div>
     </div>
   );

--- a/package/dashboards/protein-dashboard/src/components/dynamicCharts/Visualize.tsx
+++ b/package/dashboards/protein-dashboard/src/components/dynamicCharts/Visualize.tsx
@@ -2,11 +2,12 @@ import VegaChart from "./VegaChart";
 import DynamicResizableBox from "./DynamicResizableBox";
 import "./styles/Visualize.css";
 import { Fade } from "react-awesome-reveal";
-import ChartControls from "./ChartControls";
 import { useEffect, useState } from "react";
 import AddNewChart from "./AddNewChart";
 import { ChartsData } from "./types";
-import { fetchCharts, fetchSamples, saveChart } from "api/api";
+import { fetchCharts, saveChart } from "api/api";
+
+import ChartControlSheet from "./ChartControlSheet";
 
 function Visualize() {
   const [selectedChartIndex, setSelectedChartIndex] = useState<number>(-1);
@@ -37,14 +38,14 @@ function Visualize() {
       return;
     }
 
-    const updatedChartData = {
+    const updatedChartData: ChartsData = {
       ...chartsData[selectedChartIndex], // Spread to create a shallow copy
-      chartSpec: newSpec, // Directly update the chartSpec
+      chart_spec: newSpec, // Directly update the chartSpec
     };
 
     const newChartsData = [...chartsData];
     newChartsData[selectedChartIndex] = updatedChartData;
-
+    
     setChartsData(newChartsData);
   };
 
@@ -89,10 +90,15 @@ function Visualize() {
                     maxConstraints={[800, 600]}
                   >
                     <div
-                      className="chartDiv"
+                      className="chartDiv relative"
                       onClick={() => setSelectedChartIndex(index)}
                     >
                       <VegaChart data={chart_data} spec={chart_spec} />
+                      <ChartControlSheet 
+                      selectedChartIndex={selectedChartIndex} 
+                      chart_spec={chart_spec}
+                      updateChartSpec={updateChartSpec}
+                       />
                     </div>
                   </DynamicResizableBox>
                 ))}
@@ -102,7 +108,7 @@ function Visualize() {
                   </div>
                 )}
               </div>
-              {chartsData.length > 0 && (
+              {/* {chartsData.length > 0 && (
                 <div className="chartControls">
                   {chartsData[selectedChartIndex] ? (
                     <ChartControls
@@ -115,7 +121,7 @@ function Visualize() {
                     "Select a chart to see controls"
                   )}
                 </div>
-              )}
+              )} */}
             </section>
           </Fade>
         ) : (

--- a/package/dashboards/protein-dashboard/src/components/dynamicCharts/styles/ChartControls.css
+++ b/package/dashboards/protein-dashboard/src/components/dynamicCharts/styles/ChartControls.css
@@ -34,6 +34,7 @@
   
   .control-select {
     height: 35px;
+    margin-left: 0;
   }
   
   .control-color {

--- a/package/dashboards/protein-dashboard/src/components/dynamicCharts/styles/Visualize.css
+++ b/package/dashboards/protein-dashboard/src/components/dynamicCharts/styles/Visualize.css
@@ -12,7 +12,7 @@
 }
 
 .charts-panel{
-    grid-column: 1 / 3;
+    grid-column: 1 / 4;
     display: flex;
     flex-wrap: wrap;
     height: 100%;

--- a/package/dashboards/protein-dashboard/src/components/dynamicCharts/types.ts
+++ b/package/dashboards/protein-dashboard/src/components/dynamicCharts/types.ts
@@ -1,4 +1,4 @@
 export type ChartsData = {
-    chartData: any,
-    chartSpec: any
+    chart_data: JSON,
+    chart_spec: JSON
   }

--- a/package/dashboards/protein-dashboard/src/components/reusableComponents/Chatbot.css
+++ b/package/dashboards/protein-dashboard/src/components/reusableComponents/Chatbot.css
@@ -35,6 +35,7 @@
     background-color: #ffe6e6;
     align-self: flex-end;
     overflow-y: auto;
+    overflow-x: auto;
   }
   
   .input-form {

--- a/package/dashboards/protein-dashboard/src/components/reusableComponents/ReusableChatbot.tsx
+++ b/package/dashboards/protein-dashboard/src/components/reusableComponents/ReusableChatbot.tsx
@@ -123,7 +123,7 @@ const ReusableChatBot: React.FC<ReusableChatbotProps> = ({
                 msg.content
               ) : msg.type == MessageContentTypeEnum.chart ? (
                 <div className="flex justify-center flex-col">
-                  <div onClick={saveChart ? () => saveChart({chartData: chartData, chartSpec : JSON.parse(msg.content)}) : () => {}} className="flex">
+                  <div onClick={saveChart ? () => saveChart({chart_data: chartData, chart_spec : JSON.parse(msg.content)}) : () => {}} className="flex">
                     <Button variant={"outline"}>Save Chart</Button>
                   </div>
                   <VegaChart data={chartData} spec={JSON.parse(msg.content)} />

--- a/package/dashboards/protein-dashboard/src/utils/apiUtils.ts
+++ b/package/dashboards/protein-dashboard/src/utils/apiUtils.ts
@@ -22,6 +22,7 @@ export const apiRequest = async <T>({ method, url, payload }: RequestConfig): Pr
     const response = await axios.request<T>(options);
     return response.data;
   } catch (error: any) {
-    window.location.href = '/service-down';
+    // window.location.href = '/service-down';
+    console.log(error);
   }
 };


### PR DESCRIPTION

### Charts created by users gets saved in the DB

<img width="1419" alt="Screenshot 2024-07-05 at 4 11 43 AM" src="https://github.com/parthasarathydNU/protien-data-visualizer/assets/113069126/42e9f678-6d45-4944-972f-b861579b67fd">

<img width="1421" alt="Screenshot 2024-07-05 at 4 12 44 AM" src="https://github.com/parthasarathydNU/protien-data-visualizer/assets/113069126/4f0491ab-d7f8-4811-932e-78ffecdeae42">

### Table Create Script

```SQL
CREATE TABLE IF NOT EXISTS public.charts
(
    chart_id uuid NOT NULL DEFAULT gen_random_uuid(),
    chart_data json,
    chart_spec json,
    CONSTRAINT charts_pkey PRIMARY KEY (chart_id)
)
```

### Moved settings tab to a sheet:

Added a small gear icon below every chart:
<img width="684" alt="image" src="https://github.com/parthasarathydNU/protien-data-visualizer/assets/113069126/476ac9eb-2d28-4dbd-9c07-0f06628b99a3">


Users can click that to tweak the chart
<img width="1440" alt="Screenshot 2024-07-05 at 4 14 32 AM" src="https://github.com/parthasarathydNU/protien-data-visualizer/assets/113069126/baac1bf4-c9f9-40ea-a6c9-8c4271d44d41">


### What can be done better : 
- [ ] The tweaking part does not work well
- [ ] The charts that can be generated is now constrained by the hardcoded data passed into the `ReusableChatBot` component in the `ChartGeneratorChat` - this sucks
- [ ] Need to come up with a much varied examples to display in the dashboard